### PR TITLE
Fixed visible toolbar after exiting fullscreen mode

### DIFF
--- a/front/openvidu-call/src/app/shared/components/stream/stream.component.ts
+++ b/front/openvidu-call/src/app/shared/components/stream/stream.component.ts
@@ -51,6 +51,17 @@ export class StreamComponent implements OnInit {
     }
   }
 
+  @HostListener('fullscreenchange', ['$event'])
+  @HostListener('webkitfullscreenchange', ['$event'])
+  @HostListener('mozfullscreenchange', ['$event'])
+  @HostListener('MSFullscreenChange', ['$event'])
+  fullscreenChange(event) {
+    if (!document.fullscreenElement) {
+      this.isFullscreen = false;
+      this.fullscreenIcon = 'fullscreen';
+    }
+  }
+
   ngOnInit() {
     this.nicknameFormControl = new FormControl(this.user.getNickname(), [Validators.maxLength(25), Validators.required]);
     this.matcher = new NicknameMatcher();


### PR DESCRIPTION
When the full-screen mode was called from the StreamComponent, the toolbar doesn't hide after exiting the full-screen mode via the Escape button.